### PR TITLE
Windows fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 
 # Exclude code files
 *.vscode/
+*.vs/
 
 # Exclude CMakeSettings.json
 CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 ﻿cmake_minimum_required(VERSION 3.19)
 
-set(CMAKE_CXX_STANDARD 20)
-
 project ("Chimera")
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 

--- a/GraphicModules/chDX12Graphics/src/GraphicsSystem/chDX12Shader.h
+++ b/GraphicModules/chDX12Graphics/src/GraphicsSystem/chDX12Shader.h
@@ -15,7 +15,7 @@
 /************************************************************************/
 #include "chPrerequisitesDX12.h"
 
-#include <chResourceDescriptors.h>
+#include <chGPUResourceDescriptors.h>
 #include <chShader.h>
 
 

--- a/chCore/src/ScreenSystem/chScreen.h
+++ b/chCore/src/ScreenSystem/chScreen.h
@@ -18,7 +18,8 @@
 #include "chScreenEventHandle.h"
 
 #if USING(CH_PLATFORM_WIN32)
-using PlatformScreen = HWND*; //TODO: Change this to HWND
+struct HWND__;
+using PlatformScreen = HWND__*;
 #elif USING(CH_PLATFORM_LINUX)
 struct SDL_Window;
 using PlatformScreen = SDL_Window*;

--- a/chCoreTest/CMakeLists.txt
+++ b/chCoreTest/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
 
 target_link_libraries(
-  chCoreTest dl
+  chCoreTest
   chCore
   chUtilities
 )

--- a/chUtilities/src/Platform/chPath.cpp
+++ b/chUtilities/src/Platform/chPath.cpp
@@ -99,7 +99,7 @@ Path::operator<(const Path& other) const {
 
 Path
 Path::operator+(const String& other) const {
-  return Path((m_path.c_str() + other));
+  return Path((m_path.generic_string() + other));
 }
 
 }  // namespace chEngineSDK

--- a/chUtilities/src/Platform/chPlatformDefines.h
+++ b/chUtilities/src/Platform/chPlatformDefines.h
@@ -97,28 +97,17 @@
 
 /************************************************************************/
 /**
- * Check for C++17 or later
- */
- /************************************************************************/
-#if __cplusplus >= 201703L
-#   define CH_CPP17_OR_LATER              IN_USE
-#else
-#   define CH_CPP17_OR_LATER              NOT_IN_USE
-#endif
-
-/************************************************************************/
-/**
  * See if we can use __forceinline or if we need to use __inline instead
  */
  /************************************************************************/
 #if USING(CH_COMPILER_MSVC)
-
+#  define CH_CPP17_OR_LATER              USE_IF(_MSVC_LANG >= 201703L)
 # if CH_COMP_VER >= 1920
-#   define  NODISCARD [[nodiscard]]
+#  define  NODISCARD [[nodiscard]]
 # else
-#   define  NODISCARD
+#  define  NODISCARD
+#  define CH_CPP17_OR_LATER                  USE_IF(__cplusplus >= 201703L)
 # endif
-
 # if CH_COMP_VER >= 1200
 #   define FORCEINLINE                     __forceinline
 #   ifndef RESTRICT 

--- a/chUtilities/src/Prerequisites/chSTDHeaders.h
+++ b/chUtilities/src/Prerequisites/chSTDHeaders.h
@@ -249,7 +249,7 @@ using BasicStringStream = basic_stringstream<T, char_traits<T>, std::allocator<T
 /**
  * @brief Wide string used primarily for handling Unicode text.
  */
-using WString = BasicString<UNICHAR>;
+using WString = std::wstring;
 
 /**
  * @brief Narrow string used primarily for handling ASCII text.


### PR DESCRIPTION
Uploading some changes that fix the compatibility with the Windows environment. These includes:
 - Adding the macro to check for the Microsoft's compiler version.
 - Use the correct definition of the Windows Handler (HWND)
 - Deleted the `dl` in the CoreTest CMakeList.
 - Change the usage from `c_sting` to `generic_string` in the `+` operator for the Path.
 - Change the definition of `WString` from `BasicString<UNICHAR>` to `std::wstring`.
 - Update the name from `chResourceDescriptors` to `chGPUResourceDescriptors`.

Also, updated the .gitignore to start ignoring the .vs folder.